### PR TITLE
Implement main sharing API

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,0 +1,129 @@
+import argon2 from 'argon2-browser';
+import { DecryptionError } from './errors.js';
+
+const cryptoObj = globalThis.crypto;
+
+/**
+ * ArrayBufferをBase64文字列に変換する
+ * @param {ArrayBuffer} buffer
+ * @returns {string}
+ */
+export function arrayBufferToBase64(buffer) {
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Base64文字列をArrayBufferに変換する
+ * @param {string} base64
+ * @returns {ArrayBuffer}
+ */
+export function base64ToArrayBuffer(base64) {
+  const binary = atob(base64);
+  const len = binary.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+/**
+ * Saltを生成する
+ * @param {number} length
+ * @returns {Uint8Array}
+ */
+export function generateSalt(length = 16) {
+  return cryptoObj.getRandomValues(new Uint8Array(length));
+}
+
+/**
+ * データ暗号化キー (DEK) を生成する
+ * @returns {Promise<CryptoKey>}
+ */
+export async function generateDek() {
+  return cryptoObj.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt']
+  );
+}
+
+/**
+ * 鍵暗号化キー (KEK) をパスワードとSaltから導出する
+ * @param {string} password
+ * @param {Uint8Array} salt
+ * @returns {Promise<CryptoKey>}
+ */
+export async function generateKek(password, salt) {
+  if (!password || !salt) throw new Error('Password and salt are required for KEK generation.');
+  const result = await argon2.hash({
+    pass: password,
+    salt: salt,
+    time: 2,
+    mem: 19456,
+    hashLen: 32,
+    parallelism: 1,
+    type: argon2.ArgonType.Argon2id,
+  });
+  return cryptoObj.subtle.importKey('raw', result.hash.buffer, { name: 'AES-GCM' }, true, ['encrypt', 'decrypt']);
+}
+
+/**
+ * DEKを文字列としてエクスポートする
+ * @param {CryptoKey} key
+ * @returns {Promise<string>}
+ */
+export async function exportKeyToString(key) {
+  const raw = await cryptoObj.subtle.exportKey('raw', key);
+  return arrayBufferToBase64(raw);
+}
+
+/**
+ * 文字列からDEKをインポートする
+ * @param {string} keyString
+ * @returns {Promise<CryptoKey>}
+ */
+export async function importKeyFromString(keyString) {
+  const raw = base64ToArrayBuffer(keyString);
+  return cryptoObj.subtle.importKey('raw', raw, { name: 'AES-GCM' }, true, ['encrypt', 'decrypt']);
+}
+
+/**
+ * AES-GCMでデータを暗号化する
+ * @param {CryptoKey} key
+ * @param {ArrayBuffer} data
+ * @param {Uint8Array} [additionalData] - AAD
+ * @returns {Promise<{ciphertext: ArrayBuffer, iv: Uint8Array}>}
+ */
+export async function encryptData(key, data, additionalData) {
+  const iv = cryptoObj.getRandomValues(new Uint8Array(12));
+  const algorithm = { name: 'AES-GCM', iv };
+  if (additionalData) {
+    algorithm.additionalData = additionalData;
+  }
+  const ciphertext = await cryptoObj.subtle.encrypt(algorithm, key, data);
+  return { ciphertext, iv };
+}
+
+/**
+ * AES-GCMでデータを復号する
+ * @param {CryptoKey} key
+ * @param {{ciphertext: ArrayBuffer, iv: Uint8Array, additionalData?: Uint8Array}} payload
+ * @returns {Promise<ArrayBuffer>}
+ */
+export async function decryptData(key, { ciphertext, iv, additionalData }) {
+  try {
+    const algorithm = { name: 'AES-GCM', iv };
+    if (additionalData) {
+      algorithm.additionalData = additionalData;
+    }
+    return await cryptoObj.subtle.decrypt(algorithm, key, ciphertext);
+  } catch (error) {
+    throw new DecryptionError('Failed to decrypt data. The key may be incorrect or the data may be corrupted.');
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,96 @@
+import {
+  generateDek, generateKek, generateSalt, encryptData, decryptData,
+  exportKeyToString, importKeyFromString, arrayBufferToBase64, base64ToArrayBuffer
+} from './crypto.js';
+import { parseShareUrl } from './url.js';
+import { InvalidLinkError, ExpiredLinkError, PasswordRequiredError } from './errors.js';
+
+/**
+ * データを暗号化し、共有用の短縮URLを生成する
+ * @param {{
+ * data: ArrayBuffer,
+ * uploadHandler: (data: ArrayBuffer) => Promise<string>,
+ * shortenUrlHandler: (url: string) => Promise<string>,
+ * password?: string,
+ * expiresIn?: number
+ * }} options
+ * @returns {Promise<string>} 最終的な共有URL
+ */
+export async function createShareLink({ data, uploadHandler, shortenUrlHandler, password, expiresIn }) {
+  const dek = await generateDek();
+  const expdate = expiresIn ? new Date(Date.now() + expiresIn) : null;
+  const aad = expdate ? new TextEncoder().encode(expdate.toISOString()) : undefined;
+
+  const { ciphertext, iv } = await encryptData(dek, data, aad);
+
+  const payloadUrl = await uploadHandler(ciphertext);
+
+  let salt = null;
+  let keyString;
+
+  if (password) {
+    salt = generateSalt();
+    const kek = await generateKek(password, salt);
+    const rawDek = await crypto.subtle.exportKey('raw', dek);
+    const encDek = await encryptData(kek, rawDek);
+    keyString = `${arrayBufferToBase64(encDek.ciphertext)}.${arrayBufferToBase64(encDek.iv)}`;
+  } else {
+    keyString = await exportKeyToString(dek);
+  }
+
+  const params = new URLSearchParams({
+    iv: arrayBufferToBase64(iv),
+    key: keyString
+  });
+  if (salt) params.set('salt', arrayBufferToBase64(salt));
+  if (expdate) params.set('expdate', expdate.toISOString());
+
+  const accessURL = await shortenUrlHandler(payloadUrl);
+
+  return `${accessURL}#${params.toString()}`;
+}
+
+/**
+ * 共有URLからデータを復号して取得する
+ * @param {{
+ * location: Location,
+ * downloadHandler: (url: string) => Promise<ArrayBuffer>,
+ * passwordPromptHandler: () => Promise<string|null>
+ * }} options
+ * @returns {Promise<ArrayBuffer>} 復号されたデータ
+ */
+export async function receiveSharedData({ location, downloadHandler, passwordPromptHandler }) {
+  const params = parseShareUrl(location);
+  if (!params) throw new InvalidLinkError('Not a valid share link.');
+
+  const { payloadUrl, key, salt, expdate, iv: ivBase64 } = params;
+
+  if (expdate && new Date() > new Date(expdate)) {
+    throw new ExpiredLinkError('This link has expired.');
+  }
+
+  let dek;
+  if (salt) {
+    const password = await passwordPromptHandler();
+    if (!password) throw new PasswordRequiredError('Password is required but was not provided.');
+    const kek = await generateKek(password, base64ToArrayBuffer(salt));
+    const [encCipher, encIv] = key.split('.');
+    const rawDek = await decryptData(kek, {
+      ciphertext: base64ToArrayBuffer(encCipher),
+      iv: new Uint8Array(base64ToArrayBuffer(encIv))
+    });
+    dek = await crypto.subtle.importKey('raw', rawDek, { name: 'AES-GCM' }, true, ['encrypt', 'decrypt']);
+  } else {
+    dek = await importKeyFromString(key);
+  }
+
+  const encryptedPayload = await downloadHandler(payloadUrl);
+  const aad = expdate ? new TextEncoder().encode(expdate) : undefined;
+
+  return await decryptData(dek, {
+    ciphertext: encryptedPayload,
+    iv: new Uint8Array(base64ToArrayBuffer(ivBase64)),
+    additionalData: aad
+  });
+}
+

--- a/src/url.js
+++ b/src/url.js
@@ -1,0 +1,23 @@
+/**
+ * URLフラグメントからパラメータを解析する
+ * @param {Location} location - window.locationオブジェクト
+ * @returns {{mode: string, salt: string|null, expdate: string|null, key: string, iv: string, payloadUrl: string}|null}
+ */
+export function parseShareUrl(location) {
+  const fragmentParams = new URLSearchParams(location.hash.substring(1));
+
+  const key = fragmentParams.get('key');
+  const iv = fragmentParams.get('iv');
+  if (!key || !iv) {
+    return null;
+  }
+
+  return {
+    mode: fragmentParams.get('mode') || 'simple',
+    salt: fragmentParams.get('salt') || null,
+    expdate: fragmentParams.get('expdate') || null,
+    key: key,
+    iv: iv,
+    payloadUrl: location.href.split('#')[0],
+  };
+}


### PR DESCRIPTION
## Summary
- add `createShareLink` to orchestrate encryption and upload
- add `receiveSharedData` to download and decrypt shared payloads

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b07a8b6108326a80c16bc5168e370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced secure data sharing via encrypted URLs, supporting password protection and optional expiration.
  - Added the ability to generate, encrypt, and decrypt data using strong cryptography.
  - Implemented shareable links containing all necessary decryption metadata.
  - Provided functions for parsing encrypted share URLs and handling secure data retrieval.

- **Bug Fixes**
  - Improved error handling for invalid, expired, or password-protected links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->