### PR TITLE
Add compression support with pako

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "saba-less-share",
       "version": "1.0.0",
       "dependencies": {
-        "argon2-browser": "^1.18.0"
+        "argon2-browser": "^1.18.0",
+        "pako": "^2.1.0"
       },
       "devDependencies": {
         "jest": "^29.0.0",
@@ -3586,6 +3587,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-json": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "argon2-browser": "^1.18.0"
+    "argon2-browser": "^1.18.0",
+    "pako": "^2.1.0"
   },
   "devDependencies": {
     "jest": "^29.0.0",


### PR DESCRIPTION
## Summary
- add pako to dependencies
- compress data in `createShareLink` when mode is `simple`
- include mode parameter in generated URL
- decompress on data retrieval for simple mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b7959ae448326b01527f03ce8f062

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a new sharing mode that compresses data before encryption, resulting in smaller share links and potentially faster transfers.
  - Share links now include a mode parameter to indicate whether compression is used.

- **Chores**
  - Updated dependencies to include the pako library for data compression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->