### PR TITLE
Implement dual encryption for cloud mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ import { createShareLink, receiveSharedData } from 'saba-less-share';
 #### オプション
 
 * `data: ArrayBuffer` — 共有したいバイナリデータ
-* `uploadHandler: (data: ArrayBuffer) => Promise<string>` — 暗号化したペイロードをアップロードし、ファイルのURLを返す関数
-* `shortenUrlHandler: (url: string) => Promise<string>` — ペイロードURLを短縮し、短縮URLを返す関数
+* `uploadHandler: (data: { ciphertext: ArrayBuffer, iv: Uint8Array }) => Promise<string>` — 暗号化したデータをアップロードし、ファイルIDを返す関数
+* `shortenUrlHandler: (url: string) => Promise<string>` — `epayload` をクエリに含むURLを短縮する関数
 * `password?: string` — （任意）DEKを暗号化するパスワード
 * `expiresIn?: number` — （任意）リンクの有効期限（ミリ秒単位）
 
@@ -63,7 +63,7 @@ console.log(link);
 #### オプション
 
 * `location: Location` — 通常は `window.location`
-* `downloadHandler: (url: string) => Promise<ArrayBuffer>` — ペイロードをダウンロードして ArrayBuffer を返す関数
+* `downloadHandler: (id: string) => Promise<{ ciphertext: ArrayBuffer, iv: Uint8Array }>` — ファイルIDから暗号化データを取得する関数
 * `passwordPromptHandler: () => Promise<string|null>` — パスワードを入力させる関数。入力なければ `null`
 
 #### 戻り値

--- a/src/url.js
+++ b/src/url.js
@@ -1,8 +1,8 @@
 /**
  * URLフラグメントからパラメータを解析する
  * @param {Location} location - window.locationオブジェクト
- * @returns {{mode: string, salt: string|null, expdate: string|null, key: string, iv: string, payloadUrl: string}|null}
- */
+ * @returns {{mode: string, salt: string|null, expdate: string|null, key: string, iv: string, epayload: string}|null}
+*/
 export function parseShareUrl(location) {
   const fragmentParams = new URLSearchParams(location.hash.substring(1));
 
@@ -12,12 +12,14 @@ export function parseShareUrl(location) {
     return null;
   }
 
+  const queryParams = new URLSearchParams(location.search);
+
   return {
     mode: fragmentParams.get('mode') || 'simple',
     salt: fragmentParams.get('salt') || null,
     expdate: fragmentParams.get('expdate') || null,
     key: key,
     iv: iv,
-    payloadUrl: location.href.split('#')[0],
+    epayload: queryParams.get('epayload') || '',
   };
 }


### PR DESCRIPTION
## Summary
- implement double encryption process for cloud mode
- parse encrypted file ID from `epayload` query parameter
- document new handler signatures

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7e9dd8b88326bd1b6bf6c0780d04