### PR TITLE
Add demo page, integration tests, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test

--- a/__tests__/SabaLessShare.integration.test.js
+++ b/__tests__/SabaLessShare.integration.test.js
@@ -1,0 +1,112 @@
+import { jest } from '@jest/globals';
+
+// Mock argon2-browser to avoid loading WASM
+jest.unstable_mockModule('argon2-browser', () => ({
+  default: {
+    hash: async ({ pass, salt }) => {
+      const data = new Uint8Array([
+        ...new TextEncoder().encode(pass),
+        ...new Uint8Array(salt)
+      ]);
+      const hash = await crypto.subtle.digest('SHA-256', data);
+      return { hash: new Uint8Array(hash) };
+    },
+    ArgonType: { Argon2id: 2 }
+  }
+}));
+
+const { createShareLink, receiveSharedData } = await import('../src/index.js');
+const { arrayBufferToBase64, base64ToArrayBuffer } = await import('../src/crypto.js');
+
+// --- テスト用のモックハンドラ ---
+const MOCK_BASE_URL = 'https://example.com/demo/';
+const cloudStorage = new Map();
+const simpleStorage = new Map();
+
+const mockUploadHandler = async (data, mode) => {
+    if (mode === 'simple') {
+        const id = `simple-${crypto.randomUUID()}`;
+        simpleStorage.set(id, data);
+        return `${MOCK_BASE_URL}?epayload=${id}`;
+    } else { // cloud
+        const fileId = `mock-file-${crypto.randomUUID()}`;
+        cloudStorage.set(fileId, data);
+        return fileId;
+    }
+};
+
+const mockShortenUrlHandler = async (url) => url; // テストでは短縮しない
+
+const mockDownloadHandler = async (idOrUrl) => {
+    if (idOrUrl.startsWith('http')) { // simple
+        const url = new URL(idOrUrl);
+        const id = url.searchParams.get('epayload');
+        if (!simpleStorage.has(id)) throw new Error('Mock simple data not found');
+        return simpleStorage.get(id);
+    } else { // cloud
+        if (!cloudStorage.has(idOrUrl)) throw new Error('Mock file not found');
+        return cloudStorage.get(idOrUrl);
+    }
+};
+
+describe('SabaLessShare Integration Tests', () => {
+
+    const originalText = 'SabaLessShareの統合テストです！';
+    const originalData = new TextEncoder().encode(originalText);
+    const password = 'test-password';
+
+    // テストケースをパラメータ化して定義
+    const testCases = [
+        { mode: 'simple', usePass: false, useExpiry: false },
+        { mode: 'simple', usePass: true, useExpiry: false },
+        { mode: 'simple', usePass: true, useExpiry: true },
+        { mode: 'cloud', usePass: false, useExpiry: false },
+        { mode: 'cloud', usePass: true, useExpiry: false },
+        { mode: 'cloud', usePass: true, useExpiry: true },
+    ];
+
+    test.each(testCases)('E2E Test: mode=$mode, password=$usePass, expiry=$useExpiry', async ({ mode, usePass, useExpiry }) => {
+        // 1. リンク生成
+        const link = await createShareLink({
+            data: originalData,
+            mode: mode,
+            uploadHandler: (data) => mockUploadHandler(data, mode),
+            shortenUrlHandler: mockShortenUrlHandler,
+            password: usePass ? password : undefined,
+            expiresIn: useExpiry ? 3600 * 1000 : undefined,
+        });
+
+        // 2. 受信シミュレーション
+        const mockLocation = new URL(link);
+        
+        const received = await receiveSharedData({
+            location: mockLocation,
+            downloadHandler: mockDownloadHandler,
+            passwordPromptHandler: async () => usePass ? password : null,
+        });
+        
+        // 3. 結果検証
+        expect(new TextDecoder().decode(received)).toBe(originalText);
+    });
+
+    it('期限切れリンクでエラーをスローすること', async () => {
+        const link = await createShareLink({
+            data: originalData,
+            mode: 'simple',
+            uploadHandler: (data) => mockUploadHandler(data, 'simple'),
+            shortenUrlHandler: mockShortenUrlHandler,
+            expiresIn: 1, // 1ミリ秒
+        });
+
+        // 意図的に待機
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        const mockLocation = new URL(link);
+
+        await expect(receiveSharedData({
+            location: mockLocation,
+            downloadHandler: mockDownloadHandler,
+            passwordPromptHandler: async () => null,
+        })).rejects.toThrow('This link has expired.');
+    });
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SabaLessShare Demo</title>
+    <style>
+        body { font-family: sans-serif; max-width: 800px; margin: 2em auto; padding: 0 1em; }
+        textarea, input, button { width: 100%; padding: 8px; margin-bottom: 10px; box-sizing: border-box; }
+        fieldset { border: 1px solid #ccc; padding: 1em; margin-bottom: 1em; }
+        #outputUrl { word-wrap: break-word; background: #f0f0f0; padding: 1em; }
+        #receivedData { white-space: pre-wrap; background: #e6f7ff; padding: 1em; }
+        .hidden { display: none; }
+    </style>
+</head>
+<body>
+    <h1>SabaLessShare Demo</h1>
+
+    <!-- リンク受信時の表示エリア -->
+    <div id="receiveView" class="hidden">
+        <h2>受信データ</h2>
+        <pre id="receivedData"></pre>
+        <button onclick="window.location.href=window.location.pathname">新規作成画面に戻る</button>
+    </div>
+
+    <!-- リンク作成時の表示エリア -->
+    <div id="createView">
+        <fieldset>
+            <legend>1. 共有データ入力</legend>
+            <textarea id="data" rows="5" placeholder="共有したいテキストを入力"></textarea>
+        </fieldset>
+
+        <fieldset>
+            <legend>2. オプション</legend>
+            <label><input type="radio" name="mode" value="simple" checked> Simple Mode (短縮URL)</label><br>
+            <label><input type="radio" name="mode" value="cloud"> Cloud Mode (ファイルID)</label><br><br>
+            <input type="password" id="password" placeholder="パスワード (任意)">
+            <input type="number" id="expiresIn" placeholder="有効期限(秒) (任意)">
+        </fieldset>
+
+        <button id="createLinkBtn">3. 共有リンクを生成</button>
+
+        <fieldset>
+            <legend>生成されたURL</legend>
+            <p>このURLをコピーして、別のタブで開いてください。</p>
+            <div id="outputUrl"></div>
+        </fieldset>
+    </div>
+
+    <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('jest').Config} */
 const config = {
-  testEnvironment: 'jest-environment-jsdom',
+  testEnvironment: 'node',
+  setupFiles: ['./jest.setup.js'],
 };
 
 export default config;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,18 @@
+import { webcrypto } from 'crypto';
+import { TextEncoder, TextDecoder } from 'util';
+import fs from 'fs';
+import { dirname, join } from 'path';
+import { createRequire } from 'module';
+
+// Ensure Web Crypto API is available
+if (!globalThis.crypto) {
+  globalThis.crypto = webcrypto;
+}
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;
+globalThis.location = new URL('https://example.com/demo/');
+
+// Provide wasm loader for argon2-browser in Node environment
+const require = createRequire(import.meta.url);
+const wasmPath = join(dirname(require.resolve('argon2-browser')), 'dist', 'argon2.wasm');
+globalThis.loadArgon2WasmBinary = () => fs.promises.readFile(wasmPath).then(buf => new Uint8Array(buf));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "type": "module",
   "scripts": {
-    "test": "jest"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "argon2-browser": "^1.18.0",

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,7 +1,10 @@
 import argon2 from 'argon2-browser';
 import { DecryptionError } from './errors.js';
+import { webcrypto as nodeCrypto } from 'crypto';
 
-const cryptoObj = globalThis.crypto;
+const cryptoObj = globalThis.crypto && globalThis.crypto.subtle
+  ? globalThis.crypto
+  : nodeCrypto;
 
 /**
  * ArrayBufferをBase64文字列に変換する


### PR DESCRIPTION
## Summary
- add demo web page under `docs/`
- implement browser demo logic
- add integration tests covering simple/cloud modes
- support Node environment in jest via setup file
- add GitHub Actions workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b8224a2b08326aaab47dcb0bec325