### PR TITLE
Fix wasm loader base64

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -14,6 +14,6 @@ build({
   allowOverwrite: true,
   format: 'iife',
   plugins: [ignoreNodeBuiltIns],
-  loader: { '.wasm': 'file' },
+  loader: { '.wasm': 'base64' },
 }).catch(() => process.exit(1));
 


### PR DESCRIPTION
## Summary
- embed WASM as base64 in esbuild config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bce85759883269b3af44daee01ab0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build process to embed WebAssembly (.wasm) files as base64-encoded data instead of external file references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->