### PR TITLE
Fix KEK generation with Uint8Array salt

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ export async function receiveSharedData({ location, downloadHandler, passwordPro
   if (salt) {
     const password = await passwordPromptHandler();
     if (!password) throw new PasswordRequiredError('Password is required but was not provided.');
-    const kek = await generateKek(password, base64ToArrayBuffer(salt));
+    const kek = await generateKek(password, new Uint8Array(base64ToArrayBuffer(salt)));
     const [encCipher, encIv] = key.split('.');
     const rawDek = await decryptData(kek, {
       ciphertext: base64ToArrayBuffer(encCipher),


### PR DESCRIPTION
## Summary
- ensure `receiveSharedData` converts the base64 salt to `Uint8Array` before generating the KEK

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bd3b283b483268573eabe9045c322