### PR TITLE
Implement automatic URL cleanup

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -2,9 +2,6 @@ import { createShareLink, receiveSharedData } from '../src/index.js';
 import { arrayBufferToBase64, base64ToArrayBuffer } from '../src/crypto.js';
 
 // --- ハンドラ定義 ---
-const a = document.createElement('a');
-a.href = './';
-const BASE_URL = a.href;
 
 // cloudモード用の簡易的なインメモリKVS
 const cloudStorage = new Map();


### PR DESCRIPTION
## Summary
- clean up shared URLs automatically in `receiveSharedData`
- remove leftover manual cleanup lines from the demo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684be2a0b86c8326b43022b13ec39a38