### PR TITLE
Implement Simple Mode payload size limit

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -25,3 +25,10 @@ export class DecryptionError extends Error {
     this.name = 'DecryptionError';
   }
 }
+
+export class PayloadTooLargeError extends Error {
+  constructor(message = 'Payload too large for simple mode. Please use Cloud Mode instead.') {
+    super(message);
+    this.name = 'PayloadTooLargeError';
+  }
+}


### PR DESCRIPTION
## Summary
- define `SIMPLE_MODE_PAYLOAD_LIMIT` constant
- throw `PayloadTooLargeError` when simple mode payload exceeds limit
- add new `PayloadTooLargeError` class
- test handling of oversized payloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c4b04c01483269064882dd37bce52