### PR TITLE
Change expdate format to YYYY-MM-DD

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ https://example.com/demo/?epayload=<base64-encoded-encrypted-file-id>#key=<key>&
 - `iv`（フラグメント）: ファイルID暗号化用のIV
 - `mode`（フラグメント）: 動作モード（`simple` または `cloud`、デフォルト: `simple`）
 - `salt`（フラグメント）: パスワード指定時のsalt（任意）
-- `expdate`（フラグメント）: 有効期限のISO文字列（任意）
+- `expdate`（フラグメント）: 有効期限の `YYYY-MM-DD` 形式の日付文字列（任意、UTCで解釈）
 
 ## モジュール構成
 


### PR DESCRIPTION
## Summary
- store `expdate` values as `YYYY-MM-DD` instead of full ISO strings
- treat expdate as end-of-day UTC when validating
- update dynamic link creation and validation
- adjust integration tests for new expiry format and add boundary checks
- document expdate change in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d3b89cca08326b587db8adcbd9c36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved expiration handling for share links so that links remain valid until the end of the specified expiration day (23:59:59.999 UTC), rather than expiring at the start of the day.
- **Documentation**
	- Clarified the expected format of the expiration date in share links to use the `YYYY-MM-DD` format interpreted as UTC.
- **Tests**
	- Enhanced and expanded tests to cover boundary conditions for link expiration, ensuring accurate validation up to the end of the expiration day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->