### PR TITLE
Implement URL shortening scheme and days-based expiry

### DIFF
--- a/__tests__/SabaLessShare.dynamic.test.js
+++ b/__tests__/SabaLessShare.dynamic.test.js
@@ -47,6 +47,12 @@ describe('Dynamic Sharing API', () => {
 
     const result = await createDynamicLink({ data: data.buffer, adapter });
 
+    expect(result.shareLink).toContain('?p=');
+    expect(result.shareLink).toContain('#');
+    expect(result.shareLink).toMatch(/k=[^&]+/);
+    expect(result.shareLink).toMatch(/i=[^&]+/);
+    expect(result.shareLink).toMatch(/m=d/);
+
     expect(adapter.create).toHaveBeenCalledTimes(2);
 
     const location = new URL(result.shareLink);
@@ -60,6 +66,12 @@ describe('Dynamic Sharing API', () => {
     const data = new TextEncoder().encode('secure data');
 
     const result = await createDynamicLink({ data: data.buffer, adapter, password });
+
+    expect(result.shareLink).toContain('?p=');
+    expect(result.shareLink).toContain('#');
+    expect(result.shareLink).toMatch(/k=[^&]+/);
+    expect(result.shareLink).toMatch(/i=[^&]+/);
+    expect(result.shareLink).toMatch(/m=d/);
 
     const location = new URL(result.shareLink);
     const received = await receiveDynamicData({ location, adapter, passwordPromptHandler: async () => password });

--- a/__tests__/SabaLessShare.integration.test.js
+++ b/__tests__/SabaLessShare.integration.test.js
@@ -74,8 +74,14 @@ describe('SabaLessShare Integration Tests', () => {
             uploadHandler: (data) => mockUploadHandler(data, mode),
             shortenUrlHandler: mockShortenUrlHandler,
             password: usePass ? password : undefined,
-            expiresIn: useExpiry ? 3600 * 1000 : undefined,
+            expiresInDays: useExpiry ? 1 : undefined,
         });
+
+        expect(link).toContain('?p=');
+        expect(link).toContain('#');
+        expect(link).toMatch(/k=[^&]+/);
+        expect(link).toMatch(/i=[^&]+/);
+        expect(link).toMatch(/m=[sc]/);
 
         // 2. 受信シミュレーション
         const mockLocation = new URL(link);
@@ -96,7 +102,7 @@ describe('SabaLessShare Integration Tests', () => {
             mode: 'simple',
             uploadHandler: (data) => mockUploadHandler(data, 'simple'),
             shortenUrlHandler: mockShortenUrlHandler,
-            expiresIn: 1, // 1ミリ秒
+            expiresInDays: -1,
         });
 
         // 意図的に待機

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,7 +35,7 @@
             <label><input type="radio" name="mode" value="simple" checked> Simple Mode (短縮URL)</label><br>
             <label><input type="radio" name="mode" value="cloud"> Cloud Mode (ファイルID)</label><br><br>
             <input type="password" id="password" placeholder="パスワード (任意)">
-            <input type="number" id="expiresIn" placeholder="有効期限(秒) (任意)">
+            <input type="number" id="expiresInDays" placeholder="有効期限(日数) (任意)">
         </fieldset>
 
         <button id="createLinkBtn">3. 共有リンクを生成</button>

--- a/docs/main.js
+++ b/docs/main.js
@@ -100,8 +100,8 @@ function handleCreate() {
         const data = new TextEncoder().encode(dataText);
         const mode = document.querySelector('input[name="mode"]:checked').value;
         const password = document.getElementById('password').value || undefined;
-        const expiresInSeconds = document.getElementById('expiresIn').value;
-        const expiresIn = expiresInSeconds ? parseInt(expiresInSeconds, 10) * 1000 : undefined;
+        const expiresInDaysVal = document.getElementById('expiresInDays').value;
+        const expiresInDays = expiresInDaysVal ? parseInt(expiresInDaysVal, 10) : undefined;
         
         try {
             outputUrlEl.textContent = "生成中...";
@@ -111,7 +111,7 @@ function handleCreate() {
                 uploadHandler,
                 shortenUrlHandler,
                 password,
-                expiresIn,
+                expiresInDays,
             });
             outputUrlEl.innerHTML = `<a href="${link}" target="_blank" rel="noopener noreferrer">${link}</a>`;
         } catch(e) {

--- a/src/dynamic.js
+++ b/src/dynamic.js
@@ -50,11 +50,11 @@ async function _reconstructDek(key, salt, password) {
  *   data: ArrayBuffer,
  *   adapter: StorageAdapter,
  *   password?: string,
- *   expiresIn?: number
+ *   expiresInDays?: number
  * }} options
  * @returns {Promise<{shareLink: string, pointerFileId: string, key: string, salt: string|null}>}
  */
-export async function createDynamicLink({ data, adapter, password, expiresIn }) {
+export async function createDynamicLink({ data, adapter, password, expiresInDays }) {
   if (!data) throw new Error("Missing required option 'data'");
   if (!adapter || typeof adapter.create !== 'function') {
     throw new Error("Missing required option 'adapter' with 'create' method");
@@ -92,16 +92,16 @@ export async function createDynamicLink({ data, adapter, password, expiresIn }) 
     keyString = await exportKeyToString(dek);
   }
 
-  const params = new URLSearchParams({ iv: arrayBufferToBase64(iv), key: keyString, mode: 'dynamic' });
-  if (salt) params.set('salt', arrayBufferToBase64(salt));
-  if (expiresIn) {
-    const expdate = new Date(Date.now() + expiresIn).toISOString();
-    params.set('expdate', expdate);
+  const params = new URLSearchParams({ i: arrayBufferToBase64(iv), k: keyString, m: 'd' });
+  if (salt) params.set('s', arrayBufferToBase64(salt));
+  if (Number.isFinite(expiresInDays)) {
+    const expdate = new Date(Date.now() + expiresInDays * 86400000).toISOString().slice(0,10);
+    params.set('x', expdate);
   }
 
   const epayload = arrayBufferToBase64(encPayload);
   const base = typeof location !== 'undefined' ? location.href.split('#')[0].split('?')[0] : '';
-  const shareLink = `${base}?epayload=${encodeURIComponent(epayload)}#${params.toString()}`;
+  const shareLink = `${base}?p=${encodeURIComponent(epayload)}#${params.toString()}`;
 
   return { shareLink, pointerFileId, key: keyString, salt: salt ? arrayBufferToBase64(salt) : null };
 }

--- a/src/dynamic.js
+++ b/src/dynamic.js
@@ -129,7 +129,7 @@ export async function receiveDynamicData({ location, adapter, passwordPromptHand
     if (!params || params.mode !== 'dynamic') throw new InvalidLinkError('Not a valid dynamic share link.');
 
     const { key, salt, iv, expdate } = params;
-    if (expdate && new Date() > new Date(expdate)) {
+    if (expdate && new Date() > new Date(expdate + 'T23:59:59.999Z')) {
       throw new ExpiredLinkError('This link has expired.');
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ export async function receiveSharedData({ location, downloadHandler, passwordPro
 
   const { key, salt, expdate, iv: ivBase64, mode } = params;
 
-  if (expdate && new Date() > new Date(expdate)) {
+  if (expdate && new Date() > new Date(expdate + 'T23:59:59.999Z')) {
     throw new ExpiredLinkError('This link has expired.');
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,14 +17,15 @@ const SIMPLE_MODE_PAYLOAD_LIMIT = 7500;
  * shortenUrlHandler: (url: string) => Promise<string>,
  * mode: 'simple' | 'cloud',
  * password?: string,
- * expiresIn?: number
+ * expiresInDays?: number
  * }} options
  * @returns {Promise<string>} 最終的な共有URL
  */
-export async function createShareLink({ data, mode, uploadHandler, shortenUrlHandler, password, expiresIn }) {
+export async function createShareLink({ data, mode, uploadHandler, shortenUrlHandler, password, expiresInDays }) {
   const dek = await generateDek();
-  const expdate = expiresIn ? new Date(Date.now() + expiresIn) : null;
-  const aad = expdate ? new TextEncoder().encode(expdate.toISOString()) : undefined;
+  const expdate = Number.isFinite(expiresInDays) ? new Date(Date.now() + expiresInDays * 86400000) : null;
+  const expStr = expdate ? expdate.toISOString().slice(0, 10) : null;
+  const aad = expStr ? new TextEncoder().encode(expStr) : undefined;
 
   let payloadToEncrypt;
   if (mode === 'simple') {
@@ -54,12 +55,13 @@ export async function createShareLink({ data, mode, uploadHandler, shortenUrlHan
   }
 
   const params = new URLSearchParams({
-    iv: arrayBufferToBase64(iv),
-    key: keyString
+    i: arrayBufferToBase64(iv),
+    k: keyString
   });
-  if (salt) params.set('salt', arrayBufferToBase64(salt));
-  if (expdate) params.set('expdate', expdate.toISOString());
-  params.set('mode', mode);
+  if (salt) params.set('s', arrayBufferToBase64(salt));
+  if (expStr) params.set('x', expStr);
+  const modeMap = { simple: 's', cloud: 'c' };
+  params.set('m', modeMap[mode] || 's');
 
   const epayload = arrayBufferToBase64(encPayload);
 
@@ -68,7 +70,7 @@ export async function createShareLink({ data, mode, uploadHandler, shortenUrlHan
   }
 
   const base = typeof location !== 'undefined' ? location.href.split('#')[0].split('?')[0] : '';
-  const accessURL = await shortenUrlHandler(`${base}?epayload=${encodeURIComponent(epayload)}`);
+  const accessURL = await shortenUrlHandler(`${base}?p=${encodeURIComponent(epayload)}`);
 
   return `${accessURL}#${params.toString()}`;
 }

--- a/src/url.js
+++ b/src/url.js
@@ -6,20 +6,23 @@
 export function parseShareUrl(location) {
   const fragmentParams = new URLSearchParams(location.hash.substring(1));
 
-  const key = fragmentParams.get('key');
-  const iv = fragmentParams.get('iv');
+  const key = fragmentParams.get('k');
+  const iv = fragmentParams.get('i');
   if (!key || !iv) {
     return null;
   }
 
   const queryParams = new URLSearchParams(location.search);
 
+  const modeMap = { s: 'simple', c: 'cloud', d: 'dynamic' };
+  const modeCode = fragmentParams.get('m') || 's';
+
   return {
-    mode: fragmentParams.get('mode') || 'simple',
-    salt: fragmentParams.get('salt') || null,
-    expdate: fragmentParams.get('expdate') || null,
+    mode: modeMap[modeCode] || 'simple',
+    salt: fragmentParams.get('s') || null,
+    expdate: fragmentParams.get('x') || null,
     key: key,
     iv: iv,
-    epayload: queryParams.get('epayload') || '',
+    epayload: queryParams.get('p') || '',
   };
 }

--- a/src/url.js
+++ b/src/url.js
@@ -6,23 +6,23 @@
 export function parseShareUrl(location) {
   const fragmentParams = new URLSearchParams(location.hash.substring(1));
 
-  const key = fragmentParams.get('k');
-  const iv = fragmentParams.get('i');
+  const key = fragmentParams.get('k') || fragmentParams.get('key');
+  const iv = fragmentParams.get('i') || fragmentParams.get('iv');
   if (!key || !iv) {
     return null;
   }
 
   const queryParams = new URLSearchParams(location.search);
 
-  const modeMap = { s: 'simple', c: 'cloud', d: 'dynamic' };
-  const modeCode = fragmentParams.get('m') || 's';
+  const modeMap = { s: 'simple', c: 'cloud', d: 'dynamic', simple: 'simple', cloud: 'cloud', dynamic: 'dynamic' };
+  const rawMode = fragmentParams.get('m') || fragmentParams.get('mode') || 's';
 
   return {
-    mode: modeMap[modeCode] || 'simple',
-    salt: fragmentParams.get('s') || null,
-    expdate: fragmentParams.get('x') || null,
+    mode: modeMap[rawMode] || 'simple',
+    salt: fragmentParams.get('s') || fragmentParams.get('salt') || null,
+    expdate: fragmentParams.get('x') || fragmentParams.get('expdate') || null,
     key: key,
     iv: iv,
-    epayload: queryParams.get('p') || '',
+    epayload: queryParams.get('p') || queryParams.get('epayload') || '',
   };
 }


### PR DESCRIPTION
## Summary
- shorten query and fragment parameter keys
- map mode codes to single letters
- change expiry option to `expiresInDays`
- update docs and demo to use new API
- adjust tests for new URL structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d3e7555f08326b27d445614efa5ed