### PR TITLE
Allow custom simple mode payload limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ import { createShareLink, receiveSharedData } from 'saba-less-share';
 * `shortenUrlHandler: (url: string) => Promise<string>` — `p` クエリを含むURLを短縮する関数
 * `password?: string` — （任意）KEKを生成するためのパスワード。指定すると、DEKがパスワードベースで暗号化される
 * `expiresInDays?: number` — （任意）リンクの有効期限（日数単位）。設定しない場合無期限。
+* `simpleModePayloadLimit?: number` — （任意）Simpleモードで許可するペイロード長の上限。デフォルトは7700文字。
 
 #### 戻り値
 
@@ -185,7 +186,7 @@ https://example.com/demo/?p=<base64-encoded-encrypted-file-id>#k=<key>&i=<iv>&m=
 - `uploadHandler` の戻り値をファイルIDとして扱う
 
 Simple Modeでは暗号化済みIDをBase64化した`p`クエリに直接埋め込みます。
-この`p`値はURLエンコード前でおよそ**7500文字**までに制限されています。
+この`p`値はURLエンコード前でおよそ**7700文字**までに制限されています。
 それ以上のデータを扱う場合はCloud Modeの利用を検討してください。
 以下は圧縮前のデータサイズと上限の関係を示したおおよその目安です（実際の圧縮率はデータ内容によって大きく変動します）。
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,6 +36,7 @@
             <label><input type="radio" name="mode" value="cloud"> Cloud Mode (ファイルID)</label><br><br>
             <input type="password" id="password" placeholder="パスワード (任意)">
             <input type="number" id="expiresInDays" placeholder="有効期限(日数) (任意)">
+            <input type="number" id="payloadLimit" placeholder="Simpleモードペイロード上限 (デフォルト: 7700)">
         </fieldset>
 
         <button id="createLinkBtn">3. 共有リンクを生成</button>

--- a/docs/main.js
+++ b/docs/main.js
@@ -102,6 +102,8 @@ function handleCreate() {
         const password = document.getElementById('password').value || undefined;
         const expiresInDaysVal = document.getElementById('expiresInDays').value;
         const expiresInDays = expiresInDaysVal ? parseInt(expiresInDaysVal, 10) : undefined;
+        const payloadLimitVal = document.getElementById('payloadLimit').value;
+        const simpleModePayloadLimit = payloadLimitVal ? parseInt(payloadLimitVal, 10) : undefined;
         
         try {
             outputUrlEl.textContent = "生成中...";
@@ -112,6 +114,7 @@ function handleCreate() {
                 shortenUrlHandler,
                 password,
                 expiresInDays,
+                simpleModePayloadLimit,
             });
             outputUrlEl.innerHTML = `<a href="${link}" target="_blank" rel="noopener noreferrer">${link}</a>`;
         } catch(e) {


### PR DESCRIPTION
## Summary
- increase simple mode default payload limit to 7700
- allow overriding the limit via `createShareLink`
- expose payload limit input on demo page
- handle the new option in demo JS
- document new option and updated limit in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d445548e48326ae9f38e59e4bc603