### PR TITLE
Implement URL-embedded simple mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,12 @@ const data = await receiveSharedData({
 
 生成されるリンクは以下の形式になります：
 
-```
-https://example.com/demo/?p=<base64-encoded-encrypted-file-id>#k=<key>&i=<iv>&m=<mode>&s=<salt>&x=<expdate>
+-```
+https://example.com/demo/?data=<encrypted-data-or-id>#k=<key>&i=<iv>&m=<mode>&s=<salt>&x=<expdate>
 ```
 
-- `p`（クエリパラメータ）: 暗号化されたファイルID
+- `data`（クエリパラメータ）: Simple Modeでは暗号化データ本体、Cloud/Dynamic Modeでは暗号化されたファイルID
+- ※互換性のため旧形式の `p`/`epayload` も読み込めます
 - `k`（フラグメント）: DEK（パスワード有りの場合は暗号化されたDEK）
 - `i`（フラグメント）: ファイルID暗号化用のIV
 - `m`（フラグメント）: 動作モード（`s` / `c` / `d`）
@@ -183,10 +184,10 @@ https://example.com/demo/?p=<base64-encoded-encrypted-file-id>#k=<key>&i=<iv>&m=
 
 - データを gzip 圧縮してから暗号化
 - 小さなテキストデータに適している
-- `uploadHandler` の戻り値をファイルIDとして扱う
+- データはURLに直接埋め込まれるため `uploadHandler` は使用しない
 
-Simple Modeでは暗号化済みIDをBase64化した`p`クエリに直接埋め込みます。
-この`p`値はURLエンコード前でおよそ**7700文字**までに制限されています。
+Simple Modeでは暗号化済みデータをBase64化した`data`クエリに直接埋め込みます。
+この`data`値はURLエンコード前でおよそ**7700文字**までに制限されています。
 それ以上のデータを扱う場合はCloud Modeの利用を検討してください。
 以下は圧縮前のデータサイズと上限の関係を示したおおよその目安です（実際の圧縮率はデータ内容によって大きく変動します）。
 
@@ -209,8 +210,8 @@ Simple Modeでは暗号化済みIDをBase64化した`p`クエリに直接埋め�
 
 1. DEK（データ暗号化キー）を生成
 2. データを暗号化（Simple Modeの場合はgzip圧縮後）
-3. 暗号化データを`uploadHandler`でアップロード
-4. ファイルIDを暗号化してクエリパラメータに格納
+3. Simple Modeでは暗号化データをBase64化して`data`クエリに格納し、Cloud Modeでは`uploadHandler`でアップロード
+4. Cloud Modeの場合、ファイルIDを暗号化してクエリパラメータに格納
 5. DEKと暗号化パラメータをフラグメントに格納
 6. 完成したURLを`shortenUrlHandler`で短縮
 
@@ -219,10 +220,9 @@ Simple Modeでは暗号化済みIDをBase64化した`p`クエリに直接埋め�
 1. URLからパラメータを解析
 2. 有効期限チェック
 3. パスワードが必要な場合は入力を求める
-4. ファイルIDを復号
-5. `downloadHandler`で暗号化データを取得
-6. データを復号（Simple Modeの場合は展開）
-7. **重要**: ブラウザ履歴からURLパラメータを削除
+4. Cloud ModeではファイルIDを復号して`downloadHandler`でデータ取得
+5. 暗号化データを復号（Simple Modeの場合は展開）
+6. **重要**: ブラウザ履歴からURLパラメータを削除
 
 ## 重要な制約事項
 

--- a/__tests__/SabaLessShare.integration.test.js
+++ b/__tests__/SabaLessShare.integration.test.js
@@ -22,32 +22,18 @@ const { PayloadTooLargeError } = await import('../src/errors.js');
 // --- テスト用のモックハンドラ ---
 const MOCK_BASE_URL = 'https://example.com/demo/';
 const cloudStorage = new Map();
-const simpleStorage = new Map();
 
 const mockUploadHandler = async (data, mode) => {
-    if (mode === 'simple') {
-        const id = `simple-${crypto.randomUUID()}`;
-        simpleStorage.set(id, data);
-        return `${MOCK_BASE_URL}?epayload=${id}`;
-    } else { // cloud
-        const fileId = `mock-file-${crypto.randomUUID()}`;
-        cloudStorage.set(fileId, data);
-        return fileId;
-    }
+    const fileId = `mock-file-${crypto.randomUUID()}`;
+    cloudStorage.set(fileId, data);
+    return fileId;
 };
 
 const mockShortenUrlHandler = async (url) => url; // テストでは短縮しない
 
-const mockDownloadHandler = async (idOrUrl) => {
-    if (idOrUrl.startsWith('http')) { // simple
-        const url = new URL(idOrUrl);
-        const id = url.searchParams.get('epayload');
-        if (!simpleStorage.has(id)) throw new Error('Mock simple data not found');
-        return simpleStorage.get(id);
-    } else { // cloud
-        if (!cloudStorage.has(idOrUrl)) throw new Error('Mock file not found');
-        return cloudStorage.get(idOrUrl);
-    }
+const mockDownloadHandler = async (id) => {
+    if (!cloudStorage.has(id)) throw new Error('Mock file not found');
+    return cloudStorage.get(id);
 };
 
 describe('SabaLessShare Integration Tests', () => {
@@ -77,7 +63,11 @@ describe('SabaLessShare Integration Tests', () => {
             expiresInDays: useExpiry ? 1 : undefined,
         });
 
-        expect(link).toContain('?p=');
+        if (mode === 'simple') {
+            expect(link).toContain('?data=');
+        } else {
+            expect(link).toContain('?p=');
+        }
         expect(link).toContain('#');
         expect(link).toMatch(/k=[^&]+/);
         expect(link).toMatch(/i=[^&]+/);
@@ -129,8 +119,8 @@ describe('SabaLessShare Integration Tests', () => {
 
         const urlObj = new URL(link);
         const qp = urlObj.searchParams;
-        qp.set('epayload', qp.get('p'));
-        qp.delete('p');
+        qp.set('epayload', qp.get('data'));
+        qp.delete('data');
         urlObj.search = '?' + qp.toString();
 
         const fp = new URLSearchParams(urlObj.hash.substring(1));
@@ -190,12 +180,12 @@ describe('SabaLessShare Integration Tests', () => {
 
     it('simpleモードでペイロードが大きすぎる場合にエラーをスローすること', async () => {
         const bigData = crypto.getRandomValues(new Uint8Array(10000));
-        const bigUploadHandler = async () => 'x'.repeat(8000);
+        const dummyHandler = jest.fn();
 
         await expect(createShareLink({
             data: bigData,
             mode: 'simple',
-            uploadHandler: bigUploadHandler,
+            uploadHandler: dummyHandler,
             shortenUrlHandler: mockShortenUrlHandler,
         })).rejects.toThrow(PayloadTooLargeError);
     });

--- a/__tests__/parseShareUrl.test.js
+++ b/__tests__/parseShareUrl.test.js
@@ -1,0 +1,26 @@
+import { parseShareUrl } from '../src/url.js';
+
+describe('parseShareUrl', () => {
+  test('simple mode url with data parameter', () => {
+    const url = new URL('https://example.com/?data=aaa#k=k&i=i&m=s');
+    const result = parseShareUrl(url);
+    expect(result.mode).toBe('simple');
+    expect(result.epayload).toBe('aaa');
+  });
+
+  test('cloud mode url with p parameter', () => {
+    const url = new URL('https://example.com/?p=bbb#k=k&i=i&m=c');
+    const result = parseShareUrl(url);
+    expect(result.mode).toBe('cloud');
+    expect(result.epayload).toBe('bbb');
+  });
+
+  test('both parameters present chooses by mode', () => {
+    const url1 = new URL('https://example.com/?data=aaa&p=bbb#k=k&i=i&m=s');
+    const url2 = new URL('https://example.com/?data=aaa&p=bbb#k=k&i=i&m=c');
+    const r1 = parseShareUrl(url1);
+    const r2 = parseShareUrl(url2);
+    expect(r1.epayload).toBe('aaa');
+    expect(r2.epayload).toBe('bbb');
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -100,15 +100,16 @@ export async function receiveSharedData({ location, downloadHandler, passwordPro
     if (!params) throw new InvalidLinkError('Not a valid share link.');
 
     const { key, salt, expdate, iv: ivBase64, mode } = params;
+    if (mode === 'cloud') {
+      if (typeof downloadHandler !== 'function') {
+        throw new Error('downloadHandler is required for cloud mode');
+      }
+    }
 
     const queryParams = new URLSearchParams(location.search);
 
-    if (mode === 'cloud') {
-      if (!params.epayload) {
-        throw new InvalidLinkError(`Invalid ${mode} mode link: missing data parameter`);
-      }
-    } else if (!queryParams.get('data') && !queryParams.get('p') && !queryParams.get('epayload')) {
-      throw new InvalidLinkError('Invalid simple mode link.');
+    if (!params.epayload) {
+      throw new InvalidLinkError(`Invalid ${mode} mode link: missing data parameter`);
     }
 
     if (expdate && new Date() > new Date(expdate + 'T23:59:59.999Z')) {

--- a/src/index.js
+++ b/src/index.js
@@ -37,18 +37,18 @@ export async function createShareLink({
   const aad = expStr ? new TextEncoder().encode(expStr) : undefined;
 
   let payloadToEncrypt;
+  let encPayload;
+  let usedIv;
   if (mode === 'simple') {
     payloadToEncrypt = pako.gzip(new Uint8Array(data)).buffer;
+    ({ ciphertext: encPayload, iv: usedIv } = await encryptData(dek, payloadToEncrypt, aad));
   } else {
     payloadToEncrypt = data;
+    const uploadData = await encryptData(dek, payloadToEncrypt, aad);
+    const fileId = await uploadHandler(uploadData);
+    const encodedId = new TextEncoder().encode(fileId);
+    ({ ciphertext: encPayload, iv: usedIv } = await encryptData(dek, encodedId, aad));
   }
-
-  const uploadData = await encryptData(dek, payloadToEncrypt, aad);
-
-  const fileId = await uploadHandler(uploadData);
-
-  const encodedId = new TextEncoder().encode(fileId);
-  const { ciphertext: encPayload, iv } = await encryptData(dek, encodedId, aad);
 
   let salt = null;
   let keyString;
@@ -64,7 +64,7 @@ export async function createShareLink({
   }
 
   const params = new URLSearchParams({
-    i: arrayBufferToBase64(iv),
+    i: arrayBufferToBase64(usedIv),
     k: keyString
   });
   if (salt) params.set('s', arrayBufferToBase64(salt));
@@ -79,7 +79,8 @@ export async function createShareLink({
   }
 
   const base = typeof location !== 'undefined' ? location.href.split('#')[0].split('?')[0] : '';
-  const accessURL = await shortenUrlHandler(`${base}?p=${encodeURIComponent(epayload)}`);
+  const paramName = mode === 'simple' ? 'data' : 'p';
+  const accessURL = await shortenUrlHandler(`${base}?${paramName}=${encodeURIComponent(epayload)}`);
 
   return `${accessURL}#${params.toString()}`;
 }
@@ -122,26 +123,32 @@ export async function receiveSharedData({ location, downloadHandler, passwordPro
   const aad = expdate ? new TextEncoder().encode(expdate) : undefined;
 
   const encPayloadBuffer = base64ToArrayBuffer(params.epayload);
+
+  if (mode === 'simple') {
+    const decryptedPayload = await decryptData(dek, {
+      ciphertext: encPayloadBuffer,
+      iv: new Uint8Array(base64ToArrayBuffer(ivBase64)),
+      additionalData: aad,
+    });
+    return pako.ungzip(new Uint8Array(decryptedPayload)).buffer;
+  }
+
   const fileIdBuffer = await decryptData(dek, {
     ciphertext: encPayloadBuffer,
     iv: new Uint8Array(base64ToArrayBuffer(ivBase64)),
-    additionalData: aad
+    additionalData: aad,
   });
   const fileId = new TextDecoder().decode(fileIdBuffer);
 
   const downloadData = await downloadHandler(fileId);
 
-    const decryptedPayload = await decryptData(dek, {
-      ciphertext: downloadData.ciphertext,
-      iv: downloadData.iv,
-      additionalData: aad
-    });
+  const decryptedPayload = await decryptData(dek, {
+    ciphertext: downloadData.ciphertext,
+    iv: downloadData.iv,
+    additionalData: aad,
+  });
 
-    if (mode === 'simple') {
-      return pako.ungzip(new Uint8Array(decryptedPayload)).buffer;
-    }
-
-    return decryptedPayload;
+  return decryptedPayload;
   } finally {
     if (typeof history !== 'undefined') {
       const base = location.href.split('#')[0].split('?')[0];

--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,19 @@ export async function receiveSharedData({ location, downloadHandler, passwordPro
 
   const { key, salt, expdate, iv: ivBase64, mode } = params;
 
+  const queryParams = new URLSearchParams(location.search);
+
+  if (mode === 'cloud') {
+    if (typeof downloadHandler !== 'function') {
+      throw new Error('downloadHandler is required for cloud mode');
+    }
+    if (!queryParams.get('p') && !queryParams.get('epayload')) {
+      throw new InvalidLinkError('Invalid cloud mode link.');
+    }
+  } else if (!queryParams.get('data') && !queryParams.get('p') && !queryParams.get('epayload')) {
+    throw new InvalidLinkError('Invalid simple mode link.');
+  }
+
   if (expdate && new Date() > new Date(expdate + 'T23:59:59.999Z')) {
     throw new ExpiredLinkError('This link has expired.');
   }

--- a/src/url.js
+++ b/src/url.js
@@ -3,6 +3,23 @@
  * @param {Location} location - window.locationオブジェクト
  * @returns {{mode: string, salt: string|null, expdate: string|null, key: string, iv: string, epayload: string}|null}
 */
+function getEpayloadByMode(mode, queryParams) {
+  if (mode === 'cloud' || mode === 'dynamic') {
+    return (
+      queryParams.get('p') ||
+      queryParams.get('epayload') ||
+      queryParams.get('data') ||
+      ''
+    );
+  }
+  return (
+    queryParams.get('data') ||
+    queryParams.get('p') ||
+    queryParams.get('epayload') ||
+    ''
+  );
+}
+
 export function parseShareUrl(location) {
   const fragmentParams = new URLSearchParams(location.hash.substring(1));
 
@@ -17,16 +34,14 @@ export function parseShareUrl(location) {
   const modeMap = { s: 'simple', c: 'cloud', d: 'dynamic', simple: 'simple', cloud: 'cloud', dynamic: 'dynamic' };
   const rawMode = fragmentParams.get('m') || fragmentParams.get('mode') || 's';
 
+  const mode = modeMap[rawMode] || 'simple';
+
   return {
-    mode: modeMap[rawMode] || 'simple',
+    mode,
     salt: fragmentParams.get('s') || fragmentParams.get('salt') || null,
     expdate: fragmentParams.get('x') || fragmentParams.get('expdate') || null,
     key: key,
     iv: iv,
-    epayload:
-      queryParams.get('data') ||
-      queryParams.get('p') ||
-      queryParams.get('epayload') ||
-      '',
+    epayload: getEpayloadByMode(mode, queryParams),
   };
 }

--- a/src/url.js
+++ b/src/url.js
@@ -23,6 +23,10 @@ export function parseShareUrl(location) {
     expdate: fragmentParams.get('x') || fragmentParams.get('expdate') || null,
     key: key,
     iv: iv,
-    epayload: queryParams.get('p') || queryParams.get('epayload') || '',
+    epayload:
+      queryParams.get('data') ||
+      queryParams.get('p') ||
+      queryParams.get('epayload') ||
+      '',
   };
 }


### PR DESCRIPTION
## Summary
- embed encrypted payload directly in query for simple mode
- handle `data` query parameter in URL parser
- adjust tests for new simple mode behaviour
- update docs to describe serverless simple mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68518ed1a7f48326b44654ab1a3fc5f1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify the use of the `data` parameter in share links, replacing references to `p` and explaining differences between Simple and Cloud modes.
  - Revised explanations of share link creation and data reception flows for both modes.

- **Bug Fixes**
  - Improved backward compatibility handling for old URL formats in tests.

- **Refactor**
  - Simplified and clarified encryption, decryption, and URL parameter handling for Simple and Cloud modes.
  - Streamlined mock upload/download handlers and related test logic.
  - Enhanced URL parsing logic to prioritize query parameters based on mode.

- **Tests**
  - Added unit tests for URL parsing behavior across modes.
  - Updated integration tests to match new URL parameter conventions and simplified mock logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->